### PR TITLE
allow _escaped_fragment_ to work without any value

### DIFF
--- a/prerender.go
+++ b/prerender.go
@@ -95,7 +95,7 @@ func (p *Prerender) ShouldPrerenderFastHttp(ctx *fasthttp.RequestCtx) bool {
 		bufferAgent := string(ctx.Request.Header.Peek("X-Bufferbot"))
 
 		// Buffer Agent or requesting an escaped fragment, request prerender
-		if bufferAgent != "" || string(ctx.FormValue("_escaped_fragment_")) != "" {
+		if bufferAgent != "" || strings.Contains(string(ctx.QueryArgs().QueryString()), "_escaped_fragment_") {
 			isRequestingPrerenderedPage = true
 		}
 
@@ -139,8 +139,12 @@ func (p *Prerender) ShouldPrerender(or *http.Request) bool {
 	if p.Options.BotsOnly {
 		bufferAgent := or.Header.Get("X-Bufferbot")
 		isRequestingPrerenderedPage := false
+
+		// var isEscapedFragment bool
+		_, isEscapedFragment := or.URL.Query()["_escaped_fragment_"]
+
 		// Buffer Agent or requesting an escaped fragment, request prerender
-		if bufferAgent != "" || or.URL.Query().Get("_escaped_fragment_") != "" {
+		if bufferAgent != "" || isEscapedFragment {
 			isRequestingPrerenderedPage = true
 		}
 

--- a/variables.go
+++ b/variables.go
@@ -5,6 +5,19 @@ import "regexp"
 var cfSchemeRegex = regexp.MustCompile("\"scheme\":\"(http|https)\"")
 
 var crawlerUserAgents = [...]string{
+	// probably better to use _escaped_fragment_ rather
+	// than risk cloaking penalties for the big 3
+	// read more here: https://developers.google.com/webmasters/ajax-crawling/docs/specification
+	// (note: while the ajax-crawling has been deprecated, it might still be useful as a balance between
+	//        reducing risk of cloaking penalties and still guaranteeing a full render for google.
+	//        because despite their claims, they still don't always wait around for all ajax requests
+	//        to complete
+
+	// uncomment the big 3 at your own risk
+	// "googlebot",
+	// "yahoo",
+	// "bingbot",
+
 	"baiduspider",
 	"facebookexternalhit",
 	"twitterbot",
@@ -15,6 +28,19 @@ var crawlerUserAgents = [...]string{
 	"showyoubot",
 	"outbrain",
 	"pinterest",
+	"pinterest/0.",
 	"developers.google.com/+/web/snippet",
 	"slackbot",
+	"vkShare",
+	"W3C_Validator",
+	"redditbot",
+	"Applebot",
+	"WhatsApp",
+	"flipboard",
+	"tumblr",
+	"bitlybot",
+	"SkypeUriPreview",
+	"nuzzel",
+	"Discordbot",
+	"Google Page Speed",
 }


### PR DESCRIPTION
### before
a value after the equal sign was required `example.com?_escaped_fragment_=true`

### after
a no equal sign or value after the equal sign is required `example.com?_escaped_fragment_`