### PR TITLE
Allow changing the user-agent list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ func main() {
 	// not recommended, but if you must, uncomment this to
 	// restrict prerendering to bots and the _escaped_fragment_ query param
 	// prerenderCloudOptions.BotsOnly = true
+	// with BotsOnly enabled, we don't include googlebot by default (to reduce cloaking penality risk), this is how you could enable it
+	// prerendercloud.CrawlerUserAgents = append(prerendercloud.CrawlerUserAgents, "googlebot")
 
 	prerenderCloud := prerenderCloudOptions.NewPrerender()
 
@@ -63,6 +65,8 @@ func main() {
 	// not recommended, but if you must, uncomment this to
 	// restrict prerendering to bots and the _escaped_fragment_ query param
 	// prerenderCloudOptions.BotsOnly = true
+	// with BotsOnly enabled, we don't include googlebot by default (to reduce cloaking penality risk), this is how you could enable it
+	// prerendercloud.CrawlerUserAgents = append(prerendercloud.CrawlerUserAgents, "googlebot")
 
 	prerenderCloud := prerenderCloudOptions.NewPrerender()
 

--- a/_examples/fasthttp.go
+++ b/_examples/fasthttp.go
@@ -15,6 +15,7 @@ func main() {
 	// not recommended, but if you must, uncomment this to
 	// restrict prerendering to bots and the _escaped_fragment_ query param
 	// prerenderCloudOptions.BotsOnly = true
+	// prerendercloud.CrawlerUserAgents = append(prerendercloud.CrawlerUserAgents, "googlebot")
 
 	prerenderCloud := prerenderCloudOptions.NewPrerender()
 

--- a/_examples/negroni.go
+++ b/_examples/negroni.go
@@ -15,6 +15,7 @@ func main() {
 	// not recommended, but if you must, uncomment this to
 	// restrict prerendering to bots and the _escaped_fragment_ query param
 	// prerenderCloudOptions.BotsOnly = true
+	// prerendercloud.CrawlerUserAgents = append(prerendercloud.CrawlerUserAgents, "googlebot")
 
 	prerenderCloud := prerenderCloudOptions.NewPrerender()
 

--- a/prerender.go
+++ b/prerender.go
@@ -100,7 +100,7 @@ func (p *Prerender) ShouldPrerenderFastHttp(ctx *fasthttp.RequestCtx) bool {
 		}
 
 		// Crawler, request prerender
-		for _, crawlerAgent := range crawlerUserAgents {
+		for _, crawlerAgent := range CrawlerUserAgents {
 			if strings.Contains(crawlerAgent, strings.ToLower(userAgent)) {
 				isRequestingPrerenderedPage = true
 				break
@@ -149,7 +149,7 @@ func (p *Prerender) ShouldPrerender(or *http.Request) bool {
 		}
 
 		// Cralwer, request prerender
-		for _, crawlerAgent := range crawlerUserAgents {
+		for _, crawlerAgent := range CrawlerUserAgents {
 			if strings.Contains(crawlerAgent, strings.ToLower(userAgent)) {
 				isRequestingPrerenderedPage = true
 				break

--- a/variables.go
+++ b/variables.go
@@ -4,7 +4,7 @@ import "regexp"
 
 var cfSchemeRegex = regexp.MustCompile("\"scheme\":\"(http|https)\"")
 
-var crawlerUserAgents = [...]string{
+var CrawlerUserAgents = []string{
 	// probably better to use _escaped_fragment_ rather
 	// than risk cloaking penalties for the big 3
 	// read more here: https://developers.google.com/webmasters/ajax-crawling/docs/specification


### PR DESCRIPTION
`prerendercloud.CrawlerUserAgents` is a slice used when the `BotsOnly` option is true, so rewrite it, or append to it to add your own user-agents. This PR is mostly for those who want to add `googlebot` to the list.

```golang
prerendercloud.CrawlerUserAgents = append(prerendercloud.CrawlerUserAgents, "googlebot")
```

**Why don't we include `googlebot` by default?**
because there's speculation/evidence that they penalize some sites that serve different content to different user-agents (which is why we recommend prerendering for all user-agents, or if you must use `BotsOnly`, setup the `_escaped_fragment_` strategy)

* https://support.google.com/webmasters/answer/66355?hl=en
* https://moz.com/blog/white-hat-cloaking-it-exists-its-permitted-its-useful